### PR TITLE
Add sorting so members are last

### DIFF
--- a/frontend/src/pages/members.tsx
+++ b/frontend/src/pages/members.tsx
@@ -21,6 +21,14 @@ const MembersPage = ({ data }) => {
         if (response.status === 200) {
           // Navigate to the actual data inside the response
           const teamsData = response.data.result.data.json;
+
+          // Sort it so members are last
+          teamsData.sort((a: Team, b: Team) => {
+            if (a.teamName === 'Mentors' && b.teamName !== 'Mentors') return 1; // a goes after b
+            if (a.teamName !== 'Mentors' && b.teamName === 'Mentors') return -1; // a goes before b
+            return 0;
+          });
+
           setTeamsData(teamsData);
 
           // Preload images


### PR DESCRIPTION
Sort teams so that the members team is last on the list view on the Teams page.

Closes #201 